### PR TITLE
README: `master` => `main` on Heroku push

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This Battlesnake uses [Ruby 2.7](https://www.ruby-lang.org/), and [Heroku](https
 
 4. [Deploy your Battlesnake code to Heroku](https://devcenter.heroku.com/articles/git#deploying-code).
     ```shell
-    git push heroku master
+    git push heroku main
     ```
 
 5. Open your new Heroku app in your browser.


### PR DESCRIPTION
- ~Heroku changed its default branch name to `main`, and~ The default branch name for GitHub repos created from this template is `main` ~too~.
- Using `git push heroku master` gives me a `src refspec master does not match any` error.